### PR TITLE
Add sweep support for trait discovery

### DIFF
--- a/src/saev/helpers.py
+++ b/src/saev/helpers.py
@@ -1,8 +1,11 @@
 # src/saev/helpers.py
 import collections.abc
+import dataclasses
+import itertools
 import logging
 import os
 import time
+import typing
 
 import beartype
 
@@ -142,3 +145,73 @@ class batched_idx:
     def __len__(self) -> int:
         """Return the number of batches."""
         return (self.total_size + self.batch_size - 1) // self.batch_size
+
+
+#################
+# SWEEP HELPERS #
+#################
+
+
+T = typing.TypeVar("T")
+
+
+@beartype.beartype
+def expand(config: dict[str, object]) -> collections.abc.Iterator[dict[str, object]]:
+    """Expand a nested dict that may contain lists into many dicts."""
+
+    yield from _expand_discrete(dict(config))
+
+
+@beartype.beartype
+def _expand_discrete(config: dict[str, object]) -> collections.abc.Iterator[dict[str, object]]:
+    if not config:
+        yield {}
+        return
+
+    key, value = config.popitem()
+
+    if isinstance(value, list):
+        for c in _expand_discrete(config):
+            for v in value:
+                yield {**c, key: v}
+    elif isinstance(value, dict):
+        for c, v in itertools.product(
+            _expand_discrete(config), _expand_discrete(value)
+        ):
+            yield {**c, key: v}
+    else:
+        for c in _expand_discrete(config):
+            yield {**c, key: value}
+
+
+@beartype.beartype
+def grid(cfg: T, sweep_dct: dict[str, object]) -> tuple[list[T], list[str]]:
+    """Generate configs from ``cfg`` according to ``sweep_dct``."""
+
+    cfgs: list[T] = []
+    errs: list[str] = []
+
+    for d, dct in enumerate(expand(sweep_dct)):
+        updates = {}
+        for key, value in dct.items():
+            attr = getattr(cfg, key)
+            if dataclasses.is_dataclass(attr) and isinstance(value, dict):
+                sub_updates = dict(value)
+                if hasattr(attr, "seed"):
+                    sub_updates["seed"] = sub_updates.get("seed", attr.seed) + getattr(
+                        cfg, "seed", 0
+                    ) + d
+                updates[key] = dataclasses.replace(attr, **sub_updates)
+            else:
+                updates[key] = value
+
+        if hasattr(cfg, "seed"):
+            updates.setdefault("seed", getattr(cfg, "seed") + d)
+
+        try:
+            cfgs.append(dataclasses.replace(cfg, **updates))
+        except Exception as err:  # pragma: no cover - passthrough for caller
+            errs.append(str(err))
+
+    return cfgs, errs
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+from saev.helpers import expand
+
+
 def test_expand():
     cfg = {"lr": [1, 2, 3]}
     expected = [{"lr": 1}, {"lr": 2}, {"lr": 3}]


### PR DESCRIPTION
## Summary
- move `expand`/`grid` helpers from `train.py` into `saev.helpers`
- use new sweep helpers in `train.py` and CUB-200 scoring script
- allow `dump_cub200_scores.py` to take a sweep file
- update expand tests to import from helpers

## Testing
- `pytest -q` *(fails: `pytest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685daa937ab48323b984a18d2241043d