### PR TITLE
Fix MatryoshkaObjective L1 calculation missing .abs()

### DIFF
--- a/src/saev/nn/objectives.py
+++ b/src/saev/nn/objectives.py
@@ -172,7 +172,7 @@ class MatryoshkaObjective(Objective):
 
         # Calculate sparsity metrics on full encoding
         l0 = (f_x > 0).float().sum(axis=1).mean(axis=0)
-        l1 = f_x.sum(axis=1).mean(axis=0)
+        l1 = f_x.abs().sum(axis=1).mean(axis=0)
         sparsity_loss = self.sparsity_coeff * l1
 
         return MatryoshkaLoss(mse_loss, sparsity_loss, l0, l1)


### PR DESCRIPTION
## Summary

Fixes #19 

This PR fixes a bug in `MatryoshkaObjective` where the L1 norm calculation was missing `.abs()`, which could result in negative L1 values when activations contain negative numbers.

## Changes

**Commit 1: Add failing test**
- Adds `test_matryoshka_l1_calculation_uses_abs()` that demonstrates the bug
- Uses an identity activation to produce negative values in activations
- Shows that `MatryoshkaObjective` produces negative L1, while `VanillaObjective` correctly produces positive L1

**Commit 2: Fix the bug**
- Changes line 175 in `src/saev/nn/objectives.py` from `f_x.sum()` to `f_x.abs().sum()`
- Aligns implementation with `VanillaObjective` (line 108)
- All Matryoshka tests now pass

## Test Results

Before fix:
```
AssertionError: Matryoshka L1 should be non-negative, got -0.7919636368751526
```

After fix:
```
8 passed, 19 deselected in 14.73s
```

## Impact

- Fixes incorrect L1 and sparsity loss calculations in `MatryoshkaObjective`
- Only affects users of the Matryoshka objective
- No breaking changes to API

🤖 Generated with [Claude Code](https://claude.com/claude-code)